### PR TITLE
Return null if user is undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -116,6 +116,7 @@ function repo(str) {
 }
 
 function user(str) {
+  if (!str || !str.length) return null;
   if (str.indexOf(':') !== -1) {
     var segs = str.split(':');
     return segs[segs.length - 1];

--- a/test.js
+++ b/test.js
@@ -106,6 +106,9 @@ describe('parse-github-url', function () {
     assert.equal(gh('http://github.com/assemble').repo, null);
     assert.equal(gh('http://github.com/assemble').repopath, null);
     assert.equal(gh('http://github.com/assemble').user, 'assemble');
+    assert.equal(gh('https://github.com').repo, null);
+    assert.equal(gh('https://github.com').repopath, null);
+    assert.equal(gh('https://github.com').user, null);
   });
   it('should get the repo:', function () {
     assert.equal(gh('assemble/verb#branch').repo, 'verb');


### PR DESCRIPTION
Parsing non-git urls (i.e. `https://google.com` ) causing the following issue:
```
TypeError: Cannot read property 'indexOf' of undefined
      at user (node_modules/get-github-url/node_modules/parse-github-url/index.js:119:10)
```
Adding simple validation fixes that.
