### PR TITLE
Include host in the result object

### DIFF
--- a/index.js
+++ b/index.js
@@ -79,6 +79,7 @@ function parse(str) {
 
   obj.branch = obj.branch || seg[2] || getBranch(obj.path, obj);
   var res = {};
+  res.host = obj.host || 'github.com';
   res.owner = obj.owner || null;
   res.name = obj.name || null;
   res.repo = obj.repo;

--- a/test.js
+++ b/test.js
@@ -176,4 +176,18 @@ describe('parse-github-url', function() {
     assert.equal(gh('https://github.com/repos/assemble/verb/zipball').name, 'verb');
     assert.equal(gh('https://github.com/repos/assemble/dot.repo/zipball').name, 'dot.repo');
   });
+  it('should get the host:', function () {
+    assert.equal(gh('git+https://github.com/assemble/verb.git').host, 'github.com');
+    assert.equal(gh('git+ssh://github.com/assemble/verb.git').host, 'github.com');
+    assert.equal(gh('git://github.com/assemble/verb').host, 'github.com');
+    assert.equal(gh('git://github.com/assemble/verb.git').host, 'github.com');
+    assert.equal(gh('git://github.one.com/assemble/verb.git').host, 'github.one.com');
+    assert.equal(gh('git://github.one.two.com/assemble/verb.git').host, 'github.one.two.com');
+    assert.equal(gh('https://github.com/assemble/verb').host, 'github.com');
+    assert.equal(gh('https://github.one.com/assemble/verb').host, 'github.one.com');
+    assert.equal(gh('https://github.one.two.com/assemble/verb').host, 'github.one.two.com');
+  });
+  it('should assume github.com is the host when not provided:', function () {
+    assert.equal(gh('assemble/verb').host, 'github.com');
+  });
 });


### PR DESCRIPTION
Thanks for the great library! This patch makes it so the result object includes the host (defaulting to github.com), particularly useful when dealing with GHE, for example.