### PR TITLE
Return null for URLs not containing a path

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,6 +25,9 @@ function parse(str) {
 
   // parse the URL
   var obj = url.parse(str);
+  if (typeof obj.path !== 'string' || !obj.path.length || typeof obj.pathname !== 'string' || !obj.pathname.length) {
+    return null;
+  }
   obj.path = trimSlash(obj.path);
   obj.pathname = trimSlash(obj.pathname);
 

--- a/test.js
+++ b/test.js
@@ -47,6 +47,7 @@ describe('parse-github-url', function() {
     assert.equal(gh('https://github.com/assemble/verb/tree/feature/dev').owner, 'assemble');
     assert.equal(gh('https://github.com/repos/assemble/verb/tarball').owner, 'assemble');
     assert.equal(gh('https://github.com/repos/assemble/verb/zipball').owner, 'assemble');
+    assert.equal(gh('foo:bar'), null);
     assert.equal(gh(), null);
     assert.equal(gh(null), null);
     assert.equal(gh(undefined), null);


### PR DESCRIPTION
When a string that parses successfully as a URL but doesn't contain a path is passed parse would fail with 'Cannot read charAt of null'.

This PR resolves that by returning null if the passed URL doesn't contain a path.