### PR TITLE
Add support of filepath

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,6 +39,10 @@ function parse(str) {
   var hasBlob = seg[2] === 'blob';
   if (hasBlob && !isChecksum(seg[3])) {
     obj.branch = seg[3];
+    if(seg.length > 4)
+    {
+      obj.filepath = seg.slice(4).join('/');
+    }
   }
 
   var blob = str.indexOf('blob');
@@ -80,7 +84,12 @@ function parse(str) {
     }
   }
 
-  obj.branch = obj.branch || seg[2] || getBranch(obj.path, obj);
+  if(!obj.branch){
+    obj.branch = seg[2] || getBranch(obj.path, obj);
+    if(seg.length > 3){
+      obj.filepath = seg.slice(3).join('/');
+    }
+  }
   var res = {};
   res.host = obj.host || 'github.com';
   res.owner = obj.owner || null;
@@ -88,6 +97,7 @@ function parse(str) {
   res.repo = obj.repo;
   res.repository = res.repo;
   res.branch = obj.branch;
+  res.filepath = obj.filepath || null;
   return res;
 }
 

--- a/test.js
+++ b/test.js
@@ -68,6 +68,18 @@ describe('parse-github-url', function() {
     assert.equal(gh('https://raw.githubusercontent.com/assemble/verb/dev/README.md').branch, 'dev');
   });
 
+  it('should get the filepath:', function() {
+    assert.equal(gh('assemble/verb#branch').filepath, null);
+    assert.equal(gh('git@github.com:assemble/verb.git#0.6.0').filepath, null);
+    assert.equal(gh('https://github.com/assemble/verb/blob/foo/README.md').filepath, 'README.md');
+    assert.equal(gh('https://github.com/assemble/verb/blob/foo/').filepath, null);
+    assert.equal(gh('https://github.com/assemble/verb/blob/foo').filepath, null);
+    assert.equal(gh('https://github.com/assemble/verb/blob/foo/bar/README.md').filepath, 'bar/README.md');
+    assert.equal(gh('https://github.com/assemble/verb/tree/dev').filepath, null);
+    assert.equal(gh('https://raw.githubusercontent.com/assemble/verb/dev/README.md').filepath, 'README.md');
+    assert.equal(gh('https://raw.githubusercontent.com/assemble/verb/dev/bar/README.md').filepath, 'bar/README.md');
+  });
+
   it('should use master branch when another branch is not defined:', function() {
     assert.equal(gh('assemble/verb').branch, 'master');
     assert.equal(gh('git://github.com/foo/bar.git').branch, 'master');


### PR DESCRIPTION
Support of return of the file path within the repository. 
Return:
1. file path in case it's a blob link or raw file content
2. null any other link