### PR TITLE
Return the correct host for git@ URLs

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,6 +29,11 @@ function parse(str) {
     return null;
   }
 
+  if (!obj.host && /^git@/.test(str) === true) {
+    // return the correct host for git@ URLs
+    obj.host = url.parse('http://' + str).host;
+  }
+
   obj.path = trimSlash(obj.path);
   obj.pathname = trimSlash(obj.pathname);
   obj.filepath = null;

--- a/test.js
+++ b/test.js
@@ -204,6 +204,10 @@ describe('parse-github-url', function() {
     assert.equal(gh('https://github.com/assemble/verb').host, 'github.com');
     assert.equal(gh('https://github.one.com/assemble/verb').host, 'github.one.com');
     assert.equal(gh('https://github.one.two.com/assemble/verb').host, 'github.one.two.com');
+    assert.equal(gh('git@gh.pages.com:assemble/verb.git').host, 'gh.pages.com');
+    assert.equal(gh('git@gh.pages.com:assemble/dot.repo.git').host, 'gh.pages.com');
+    assert.equal(gh('git@bitbucket.org:atlassian/atlaskit.git').host, 'bitbucket.org');
+    assert.equal(gh('git@gitlab.com:gitlab-org/gitlab-ce.git').host, 'gitlab.com');
   });
 
   it('should assume github.com is the host when not provided:', function() {


### PR DESCRIPTION
Fixes https://github.com/jonschlinkert/parse-github-url/issues/10

Node's built in `url` function doesn't seem to return the correct `host` for `git@*` urls:

```node
λ node -e "console.log(require('url').parse('git@gh.pages.com:assemble/verb.git'))"
Url {
  protocol: null,
  slashes: null,
  auth: null,
  host: null,
  port: null,
  hostname: null,
  hash: null,
  search: null,
  query: null,
  pathname: 'git@gh.pages.com:assemble/verb.git',
  path: 'git@gh.pages.com:assemble/verb.git',
  href: 'git@gh.pages.com:assemble/verb.git' }
```

But it does if you stick a valid protocol in front:

```node
λ node -e "console.log(require('url').parse('http://git@gh.pages.com:assemble/verb.git'))"
Url {
  protocol: 'http:',
  slashes: true,
  auth: 'git',
  host: 'gh.pages.com',
  port: null,
  hostname: 'gh.pages.com',
  hash: null,
  search: null,
  query: null,
  pathname: '/:assemble/verb.git',
  path: '/:assemble/verb.git',
  href: 'http://git@gh.pages.com/:assemble/verb.git' }
```

This PR checks if `host` is empty and the URL start with `git@` and parses the URL with `http://` prepended, to give us the correct host.

Tests added, and all existing tests pass.