### PR TITLE
add cli support

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+
+var gh = require('./');
+
+if (!process.argv[2]) {
+  process.stderr.write('Error: URL must be provided as first argument\n');
+  process.exit(1);
+}
+var res = gh(process.argv[2]);
+if (res == null) {
+  process.stderr.write('Error: Invalid parameter: ' + process.argv[2] + '\n');
+  process.exit(1);
+}
+process.stdout.write(JSON.stringify(res, null, 2) + '\n');

--- a/package.json
+++ b/package.json
@@ -21,6 +21,9 @@
   "files": [
     "index.js"
   ],
+  "bin": {
+    "parse-github-url" : "./cli.js"
+  },
   "main": "index.js",
   "engines": {
     "node": ">=0.10.0"


### PR DESCRIPTION
Adds support to use the module as a cli tool

```sh
$ npm install -g parse-github-url 

$ parse-github-url https://github.com/jmendiara/parse-github-url.git
{
  "protocol": "https:",
  "slashes": true,
  "auth": null,
  "host": "github.com",
  "port": null,
  "hostname": "github.com",
  "hash": null,
  "search": null,
  "query": null,
  "pathname": "jmendiara/parse-github-url.git",
  "path": "jmendiara/parse-github-url.git",
  "href": "https://github.com/jmendiara/parse-github-url.git",
  "filepath": null,
  "owner": "jmendiara",
  "name": "parse-github-url",
  "repo": "jmendiara/parse-github-url",
  "branch": "master",
  "repository": "jmendiara/parse-github-url"
}
```