### PR TITLE
Handle blob and tree being in owner and project name

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,12 +52,13 @@ function parse(str) {
   }
 
   var blob = str.indexOf('blob');
-  if (blob !== -1) {
+  if (hasBlob && blob !== -1) {
     obj.blob = str.slice(blob + 5);
   }
 
+  var hasTree = seg[2] === 'tree';
   var tree = str.indexOf('tree');
-  if (tree !== -1) {
+  if (hasTree && tree !== -1) {
     var idx = tree + 5;
     var branch = str.slice(idx);
     var slash = branch.indexOf('/');

--- a/test.js
+++ b/test.js
@@ -66,6 +66,7 @@ describe('parse-github-url', function() {
     assert.equal(gh('https://raw.githubusercontent.com/assemble/verb/4d0ebde055557a0d1d988c01e0f070df8cc8fa07').branch, '4d0ebde055557a0d1d988c01e0f070df8cc8fa07');
     assert.equal(gh('https://raw.githubusercontent.com/assemble/verb/4d0ebde055557a0d1d988c01e0f070df8cc8fa07/README.md').branch, '4d0ebde055557a0d1d988c01e0f070df8cc8fa07');
     assert.equal(gh('https://raw.githubusercontent.com/assemble/verb/dev/README.md').branch, 'dev');
+    assert.equal(gh('https://github.com/contentful/extensions/blob/master/samples/content-tree/extension.json').branch, 'master');
   });
 
   it('should get the filepath:', function() {
@@ -78,6 +79,14 @@ describe('parse-github-url', function() {
     assert.equal(gh('https://github.com/assemble/verb/tree/dev').filepath, null);
     assert.equal(gh('https://raw.githubusercontent.com/assemble/verb/dev/README.md').filepath, 'README.md');
     assert.equal(gh('https://raw.githubusercontent.com/assemble/verb/dev/bar/README.md').filepath, 'bar/README.md');
+    assert.equal(gh('https://github.com/owner/blob/blob/foo/README.md').filepath, 'README.md');
+    assert.equal(gh('https://github.com/blob/project/blob/foo/README.md').filepath, 'README.md');
+    assert.equal(gh('https://github.com/owner/tree/tree/foo/README.md').filepath, null);
+    assert.equal(gh('https://github.com/tree/project/tree/foo/README.md').filepath, null);
+    assert.equal(gh('https://raw.githubusercontent.com/owner/tree/dev/README.md').filepath, 'README.md');
+    assert.equal(gh('https://raw.githubusercontent.com/tree/project/dev/README.md').filepath, 'README.md');
+    assert.equal(gh('https://raw.githubusercontent.com/owner/blob/dev/README.md').filepath, 'README.md');
+    assert.equal(gh('https://raw.githubusercontent.com/blob/project/dev/README.md').filepath, 'README.md');
   });
 
   it('should use master branch when another branch is not defined:', function() {


### PR DESCRIPTION
I stumbled upon a problem trying to parse `https://github.com/helion3/inspire-tree/issues/183`.
I discovered the project name containing `tree` being the problem.

I've added test cases and then implemented a fix.

Thank you for this package!

Fixes #16