### PR TITLE
Set branch to master for a blob with checksum

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,10 +44,15 @@ function parse(str) {
 
   var seg = obj.path.split('/').filter(Boolean);
   var hasBlob = seg[2] === 'blob';
-  if (hasBlob && !isChecksum(seg[3])) {
-    obj.branch = seg[3];
-    if (seg.length > 4) {
-      obj.filepath = seg.slice(4).join('/');
+  if (hasBlob) {
+    if (isChecksum(seg[3])) {
+      obj.branch = 'master'
+    }
+    else {
+      obj.branch = seg[3];
+      if (seg.length > 4) {
+        obj.filepath = seg.slice(4).join('/');
+      }
     }
   }
 

--- a/test.js
+++ b/test.js
@@ -66,6 +66,7 @@ describe('parse-github-url', function() {
     assert.equal(gh('https://raw.githubusercontent.com/assemble/verb/4d0ebde055557a0d1d988c01e0f070df8cc8fa07').branch, '4d0ebde055557a0d1d988c01e0f070df8cc8fa07');
     assert.equal(gh('https://raw.githubusercontent.com/assemble/verb/4d0ebde055557a0d1d988c01e0f070df8cc8fa07/README.md').branch, '4d0ebde055557a0d1d988c01e0f070df8cc8fa07');
     assert.equal(gh('https://raw.githubusercontent.com/assemble/verb/dev/README.md').branch, 'dev');
+    assert.equal(gh('https://github.com/assemble/verb/blob/4ea41d0d11292c3a4788040bb822e7a6d88784de/README.md#heading1').branch, 'master');
   });
 
   it('should get the filepath:', function() {


### PR DESCRIPTION
Set branch to "master" for a blob with checksum. Fixes #17. The branch was incorrectly being sent to "blob". 

Presumably the hash refers to an anchor (e.g. a markdown heading) rather than a branch in this case.