### PR TITLE
Add `url` dependency for browser compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 > Parse a github URL into an object.
 
+Identical to `parse-github-url`, except using the `url` NPM package as a browser polyfill for Node's built-in `url` package.
+
 Please consider following this project's author, [Jon Schlinkert](https://github.com/jonschlinkert), and consider starring the project to show your :heart: and support.
 
 ## Install

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "Jon Schlinkert (http://twitter.com/jonschlinkert)",
     "Pete Cook (cookpete.com)",
     "Philipp Alferov (https://github.com/alferov)",
-    "William Bartholomew (https://willbar.com)"
+    "William Bartholomew (https://willbar.com)",
+    "Ryan Vandersmith (https://ryanvandersmith.com)"
   ],
   "repository": "jonschlinkert/parse-github-url",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,9 @@
   "scripts": {
     "test": "mocha"
   },
+  "dependencies" : {
+    "url": "^0.11.0"
+  },
   "devDependencies": {
     "gulp-format-md": "^1.0.0",
     "mocha": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "parse-github-url",
+  "name": "isomorphic-parse-github-url",
   "description": "Parse a github URL into an object.",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "homepage": "https://github.com/jonschlinkert/parse-github-url",
   "author": "Jon Schlinkert (https://github.com/jonschlinkert)",
   "contributors": [
@@ -34,8 +34,8 @@
   "scripts": {
     "test": "mocha"
   },
-  "dependencies" : {
-    "url": "^0.11.0"
+  "dependencies": {
+    "url": "^0.11.4"
   },
   "devDependencies": {
     "gulp-format-md": "^1.0.0",


### PR DESCRIPTION
This package causes a variety of issues with recent versions of [create-react-app](https://create-react-app.dev/) and [Vite](https://vitejs.dev/) projects due to the need for a polyfill of Node's `url` module. This PR adds the `url` npm package as a dependency to make this package work out-of-the-box in the latest version of Webpack and other front-end bundlers. 

In the meantime, the npm package `isomorphic-parse-github-url` is available as a short-term solution. 

This change passes all tests and works as expected in [a production web application](https://github.com/dfinity/embed-motoko).
