### PR TITLE
Return null if there's no branch

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ function getBranch(str, obj) {
 	if (!branch && obj.hash && obj.hash.charAt(0) === '#') {
 		branch = obj.hash.slice(1);
 	}
-	return branch || 'master';
+	return branch;
 }
 
 function trimSlash(path) {


### PR DESCRIPTION
If there's no branch, prefer to return null, since many repos are now using "main" as default