### PR TITLE
fix: deprecation of url.parse

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@
 
 'use strict';
 
-var url = require('url');
+var parseURL = require('./parse-url');
 var cache = { __proto__: null };
 
 function isChecksum(str) {
@@ -45,6 +45,14 @@ function owner(str) {
 	return str;
 }
 
+/**
+ * Extract the host from a git@ URL using the WHATWG URL API.
+ */
+function getGitAtHost(str) {
+	var transformed = 'http://' + str.replace(/git@([^:]+):/, '$1/');
+	return parseURL(transformed).host || null;
+}
+
 function parse(str) {
 	if (typeof str !== 'string' || !str.length) {
 		return null;
@@ -55,14 +63,14 @@ function parse(str) {
 	}
 
 	// parse the URL
-	var obj = url.parse(str);
+	var obj = parseURL(str);
 	if (typeof obj.path !== 'string' || !obj.path.length || typeof obj.pathname !== 'string' || !obj.pathname.length) {
 		return null;
 	}
 
 	if (!obj.host && (/^git@/).test(str) === true) {
 		// return the correct host for git@ URLs
-		obj.host = url.parse('http://' + str.replace(/git@([^:]+):/, '$1/')).host;
+		obj.host = getGitAtHost(str);
 	}
 
 	obj.path = trimSlash(obj.path);

--- a/parse-url.js
+++ b/parse-url.js
@@ -1,0 +1,78 @@
+'use strict';
+
+var urlModule = require('url');
+var URLCtor = typeof URL === 'undefined' ? urlModule.URL || null : URL;
+var legacyURLParse = URLCtor ? null : urlModule.parse;
+
+function parseWHATWG(str) {
+	try {
+		var u = new URLCtor(str);
+		var auth = null;
+		if (u.username) {
+			auth = u.password ? u.username + ':' + u.password : u.username;
+		}
+		var host = u.host || null;
+		var hostname = u.hostname || null;
+		var pathname = u.pathname || null;
+		var path = u.pathname + (u.search || '') || null;
+
+		// For non-special schemes without '//' (e.g. 'github:user/repo', 'foo:bar'),
+		// the WHATWG URL API produces an opaque path (host is empty). Replicate the
+		// legacy url.parse() behavior: treat the first path segment as the host.
+		if (!host && pathname && str.indexOf('//') === -1) {
+			var slashIdx = pathname.indexOf('/');
+			if (slashIdx === -1) {
+				// e.g. 'foo:bar' — no path segment, only a host-like token → null path
+				host = pathname;
+				hostname = pathname;
+				pathname = null;
+				path = null;
+			} else {
+				// e.g. 'github:user/repo' — first segment is host, rest is path
+				host = pathname.slice(0, slashIdx);
+				hostname = host;
+				pathname = pathname.slice(slashIdx);
+				path = pathname + (u.search || '');
+			}
+		}
+
+		return {
+			auth: auth,
+			hash: u.hash || null,
+			host: host,
+			hostname: hostname,
+			href: u.href,
+			path: path,
+			pathname: pathname,
+			port: u.port || null,
+			protocol: u.protocol || null,
+			query: u.search ? u.search.slice(1) : null,
+			search: u.search || null,
+			slashes: str.indexOf('//') === -1 ? null : true
+		};
+	} catch (_) {
+		// Fall back for non-standard strings (bare paths, git@ URLs, etc.)
+		var hashIdx = str.indexOf('#');
+		var hash = hashIdx === -1 ? null : str.slice(hashIdx);
+		var pathPart = hashIdx === -1 ? str : str.slice(0, hashIdx);
+		var queryIdx = pathPart.indexOf('?');
+		var search = queryIdx === -1 ? null : pathPart.slice(queryIdx);
+		var pathnamePart = queryIdx === -1 ? pathPart : pathPart.slice(0, queryIdx);
+		return {
+			auth: null,
+			hash: hash,
+			host: null,
+			hostname: null,
+			href: str,
+			path: pathPart || null,
+			pathname: pathnamePart || null,
+			port: null,
+			protocol: null,
+			query: search ? search.slice(1) : null,
+			search: search,
+			slashes: null
+		};
+	}
+}
+
+module.exports = URLCtor ? parseWHATWG : legacyURLParse;

--- a/test/index.js
+++ b/test/index.js
@@ -5,9 +5,12 @@ var test = require('tape');
 var gh = require('../');
 
 test('parse-github-url', function (t) {
-	process.on('warning', function (e) {
+	function failOnWarn(e) {
 		t.fail(e, 'no deprecation warnings are issued');
-	});
+	}
+
+	process.on('warning', failOnWarn);
+	t.teardown(function () { process.removeListener('warning', failOnWarn); });
 
 	t.equal(gh('toString').href, 'toString');
 
@@ -247,4 +250,5 @@ test('parse-github-url', function (t) {
 
 		assert.end();
 	});
+
 });

--- a/test/parse-url.js
+++ b/test/parse-url.js
@@ -1,0 +1,32 @@
+'use strict';
+
+var test = require('tape');
+var urlParse = require('url').parse;
+var parseURL = require('../parse-url');
+
+test('parse-url', function (t) {
+	t.test('matches url.parse() for key properties:', function (st) {
+		var props = ['auth', 'hash', 'host', 'hostname', 'path', 'pathname', 'protocol', 'slashes'];
+		var urls = [
+			'https://github.com/assemble/verb.git',
+			'git://github.com/assemble/verb.git',
+			'git@github.com:assemble/verb.git',
+			'github:user/repo',
+			'assemble/verb',
+			'foo:bar',
+			'assemble/verb?tab=readme',
+			'assemble/verb?tab=readme#section',
+			'git@github.com:assemble/verb.git?foo=bar'
+		];
+
+		urls.forEach(function (url) {
+			var expected = urlParse(url);
+			var actual = parseURL(url);
+			props.forEach(function (prop) {
+				st.equal(actual[prop], expected[prop], url + ' — ' + prop);
+			});
+		});
+
+		st.end();
+	});
+});


### PR DESCRIPTION
Fixes #34.

#  Problem

  Node.js v24 introduced DEP0169, a deprecation warning for url.parse():

  (node:1234) [DEP0169] DeprecationWarning: `url.parse()` behavior is not standardized
  and prone to errors that have security implications. Use the WHATWG URL API instead.

  This library called url.parse() in two places, causing the warning to be emitted to stderr whenever the library was used. Downstream projects that assert on clean stderr (e.g. in tests) were broken as a
  result.

#  Solution

Try to detect if the WHATWG URL API exists, and if it does, replace both url.parse() calls with a polyfill using the new API.

(Claude helped me write this PR.)